### PR TITLE
Fix dashboard crashes by emitting frames on main thread

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,22 +1,32 @@
 import sys
-from PyQt5.QtWidgets import QApplication
-from newDashboard import MainDashboard
 import threading
+from PyQt5.QtWidgets import QApplication
+from PyQt5.QtCore import QObject, pyqtSignal, QTimer
+
+from newDashboard import MainDashboard
+
+
+class FrameEmitter(QObject):
+    """Forward camera frames safely to the GUI thread"""
+
+    frame_ready = pyqtSignal(object)
 
 if __name__ == "__main__":
     app = QApplication(sys.argv)
     window = MainDashboard()
 
+    emitter = FrameEmitter()
+    emitter.frame_ready.connect(window.realtime_tab.update_frame)
+
     from logic import camera_module
 
     def frame_callback(img):
-        window.realtime_tab.update_frame(img)
+        emitter.frame_ready.emit(img)
         return img  # geen bewerking
 
     def start_camera():
         camera_module.start_stream(callback=frame_callback)
 
-    from PyQt5.QtCore import QTimer
     QTimer.singleShot(100, lambda: threading.Thread(target=start_camera, daemon=True).start())
 
     window.show()


### PR DESCRIPTION
## Summary
- avoid updating Qt widgets from non-GUI thread
- emit camera frames via `pyqtSignal` and handle them on the main GUI thread

## Testing
- `python -m py_compile main.py newDashboard.py logic/*.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68419715bb0083228ff90c99b66d8550